### PR TITLE
upload: add hw_rng_model=virtio property

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,6 +72,8 @@ def cmd_upload(args):
     print("INFO: creating image")
     new_img = glance.images.create(disk_format='qcow2',
                                    container_format='bare')
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1572944
+    glance.images.update(new_img.id, hw_rng_model='virtio')
     print("INFO: new image ID is", new_img.id)
 
     try:


### PR DESCRIPTION
So that OpenStack knows that we want a virtio-rng device added if
possible. This is good practice, but also a workaround for the current
issues in the 4.16.4 kernel:

https://bugzilla.redhat.com/show_bug.cgi?id=1572944