### PR TITLE
use v3 authentication

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,10 +33,12 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--auth-url', default=os.environ.get('OS_AUTH_URL'))
     parser.add_argument('--project-id', default=os.environ.get('OS_PROJECT_ID'))
-    parser.add_argument('--project-domain-id',
-                        default=os.environ.get('OS_PROJECT_DOMAIN_ID'))
     parser.add_argument('--username', default=os.environ.get('OS_USERNAME'))
     parser.add_argument('--password', default=os.environ.get('OS_PASSWORD'))
+    # needed for v3
+    parser.add_argument('--user-domain-name', default=os.environ.get('OS_USER_DOMAIN_NAME'))
+    parser.add_argument('--project-domain-id', default=os.environ.get('OS_PROJECT_DOMAIN_ID'))
+
     subparsers = parser.add_subparsers(dest='cmd', title='subcommands')
     subparsers.required = True
 
@@ -47,8 +49,8 @@ def parse_args():
                         help='delete all other images of the same name')
     upload.add_argument('--image-id-file', metavar='FILE',
                         help='write image ID to a file')
-    upload.add_argument('--share-with', action='append', metavar='TENANT_ID',
-                        default=[], help='ID of tenant to share with (this '
+    upload.add_argument('--share-with', action='append', metavar='PROJECT_ID',
+                        default=[], help='id of project to share with (this '
                         'option can be repeated)')
     upload.set_defaults(func=cmd_upload)
 
@@ -82,35 +84,30 @@ def cmd_upload(args):
         print("INFO: uploading image")
         upload_image_from_url(glance, new_img.id, args.url)
 
-        # remove self from the list of tenants with which to share
-        if args.tenant_id in args.share_with:
-            args.share_with.remove(args.tenant_id)
+        # remove self from the list of projects with which to share
+        if args.project_id in args.share_with:
+            args.share_with.remove(args.project_id)
 
         if len(args.share_with) > 0:
-            print("INFO: sharing with tenants")
-            for tenant in args.share_with:
-                glance.image_members.create(new_img.id, tenant)
+            print("INFO: sharing with projects")
+            for project in args.share_with:
+                glance.image_members.create(new_img.id, project)
 
             # We actually don't *have* to do the below. The image is
-            # already accessible in the tenants, though they won't
+            # already accessible in the projects, though they won't
             # show up in a full listing until accepted. So let's try
             # to be nice.
 
-            # We only support sharing with tenants under the same
+            # We only support sharing with projects under the same
             # username/password.
 
             # XXX: Consider making this part optional since it assumes
-            # we have access to the other tenants.
-            accept_image_in_tenants(new_img.id, args.share_with,
-                                    args.project_domain_id, args.auth_url,
+            # we have access to the other projects.
+            accept_image_in_projects(new_img.id, args.share_with, args.auth_url,
                                     args.username, args.password)
-
         if args.name:
-            # The Python API is not fully compatible with v2 yet,
-            # e.g. update() is spotty, so let's use v1.
-            glance1 = glance_session_from_args(args, 1)
             print("INFO: renaming to", args.name)
-            glance1.images.update(new_img.id, name=args.name)
+            glance.images.update(new_img.id, name=args.name)
 
         if args.image_id_file:
             print("INFO: write image id to file", args.image_id_file)
@@ -132,35 +129,32 @@ def cmd_rename(args):
     print("INFO: authenticating")
     glance = glance_session_from_args(args)
 
-    # The Python API is not fully compatible with v2 yet,
-    # e.g. update() is spotty, so let's use v1.
-    glance1 = glance_session_from_args(args, 1)
     print("INFO: renaming to", args.name)
-    glance1.images.update(args.image_id, name=args.name)
+    glance.images.update(args.image_id, name=args.name)
 
     if args.unique:
         print("INFO: deleting other images of the same name")
         make_image_unique_by_name(glance, args.image_id, args.name)
 
 
-def glance_session(auth_url, project_id, project_domain_id, username, password, version=2):
+def glance_session(auth_url, project_id, username, password,
+                   project_domain_id, user_domain_name, version=2):
     auth = v3.Password(auth_url=auth_url,
                        project_id=project_id,
                        username=username,
                        password=password,
                        project_domain_id=project_domain_id,
-                       user_domain_name='redhat.com')
+                       user_domain_name=user_domain_name)
+
     mysession = session.Session(auth=auth)
 
-    # the Python API is not fully compatible with v2 yet,
-    # e.g. update() is spotty
     return Client(version, session=mysession)
 
 
 def glance_session_from_args(args, version=2):
-    return glance_session(args.auth_url, args.project_id,
-                          args.project_domain_id,
-                          args.username, args.password, version)
+    return glance_session(args.auth_url, args.project_id, args.username,
+                          args.password, args.project_domain_id,
+                          args.user_domain_name, version)
 
 
 def find_images_by_name(glance, name):
@@ -192,19 +186,19 @@ def upload_image_from_url(glance, img, image_url):
     glance.images.upload(img, f_in)
 
 
-def accept_image_in_tenants(img, projects, project_domain_id, auth_url,
-                            username, password):
+def accept_image_in_projects(img, projects, auth_url, project_domain_id,
+                             user_domain_name, username, password):
     for project in projects:
-        glance = glance_session(auth_url, project, project_domain_id,
-                                username, password)
-        glance.image_members.update(img, tenant, 'accepted')
+        glance = glance_session(auth_url, project, username, password,
+                                project_domain_id, user_domain_name)
+        glance.image_members.update(img, project, 'accepted')
 
 
 def make_image_unique_by_name(glance, img_id, name):
     imgs = find_images_by_name(glance, name)
     imgs = [img for img in imgs if img.id != img_id]
     for img in imgs:
-        # NB: This assumes that we're in the same tenant as
+        # NB: This assumes that we're in the same project as
         # the one that originally uploaded the image(s).
         # Otherwise, we'd get a 403.
         glance.images.delete(img.id)


### PR DESCRIPTION
Openstack uses v3 authentication now so lets start using it.  v3
authenticatoin requires a few more environment variables and replaces
the concept of tenants with projects.

Glance Client v1 also seemed to be incompatible with the newer version
of Openstack so use v2 for all commands now.